### PR TITLE
properly encode and decode text before and after translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "axios": "^0.27.2",
+    "he": "^1.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.2",
@@ -50,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "@types/he": "^1.1.2",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "eslint": "^8.15.0",

--- a/src/api-fetch-translations/fetchTranslation.ts
+++ b/src/api-fetch-translations/fetchTranslation.ts
@@ -16,7 +16,7 @@ const dummyResponse = {
 };
 
 axios.defaults.baseURL = process.env.REACT_APP_GOOGLE_TRANSLATE_URL;
-const apiKey = process.env.REACT_APP_GOOGLE_CLOUD_API_KEY;
+const apiKey = process.env.REACT_APP_GOOGLE_CLOUD_API_KEY || "";
 
 // // dummy API response (so I don't use up my API quota)
 // // @ts-ignore
@@ -35,9 +35,15 @@ const fetchTranslation = async (
   targetLang: Language,
   textToTranslate: TranslationText
 ) => {
+  const urlEncoded = `language/translate/v2/?key=${encodeURIComponent(
+    apiKey
+  )}&q=${encodeURIComponent(textToTranslate)}&target=${encodeURIComponent(
+    targetLang
+  )}&source=${encodeURIComponent(sourceLang)}`;
+
   const params: RequestParams = {
     method: "POST",
-    url: `language/translate/v2/?key=${apiKey}&q=${textToTranslate}&target=${targetLang}&source=${sourceLang}`,
+    url: urlEncoded,
   };
 
   return axios.request(params);

--- a/src/sagas/translationSaga.ts
+++ b/src/sagas/translationSaga.ts
@@ -1,4 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
+import he from "he";
 import { selectOriginLang, selectOriginText, selectSteps } from "../redux/selectors";
 import { fetchTranslation } from "../api-fetch-translations/fetchTranslation";
 import {
@@ -30,9 +31,11 @@ function* fetchStepTranslation(
   // @ts-ignore
   const response = yield call(fetchTranslation, sourceLang, targetLang, textToTranslate);
   const translation = response.data.data.translations[0].translatedText;
+  const translationDecoded = he.decode(translation);
+
   yield put({
     type: UPDATE_STEP_TEXT,
-    payload: { stepIndexToUpdate: stepIndex, newText: translation },
+    payload: { stepIndexToUpdate: stepIndex, newText: translationDecoded },
   });
   yield put({
     type: UPDATE_STEP_IS_FETCHING,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,6 +1900,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/he@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/he/-/he-1.1.2.tgz#0c8b275f36d2b8b651104638e4d45693349c3953"
+  integrity sha512-kSJPcLO1x+oolc0R89pUl2kozldQ/fVQ1C1p5mp8fPoLdF/ZcBvckaTC2M8xXh3GYendXvCpy5m/a2eSbfgNgw==
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"


### PR DESCRIPTION
resolves #14

- uses library `he` to decode received translation
- uses `encodeURIComponent` to encode translation (and all request params) before sending request